### PR TITLE
Randomize thread ID, and minor fixes

### DIFF
--- a/integration/orb.yaml
+++ b/integration/orb.yaml
@@ -1,4 +1,2 @@
 type: meya.orb.integration
 identity_verification: false
-collect:
-  context: user_overwrite

--- a/public/strava_free_user.html
+++ b/public/strava_free_user.html
@@ -1696,17 +1696,20 @@ Find and Invite Your Friends
   });
 </script>
 <script type="text/javascript">
+  function randomThreadId() {
+    return Math.floor(Math.random() * 1000).toString();
+}
 window.orbConfig = {
      connectionOptions: {
         gridUrl: "https://grid.meya.ai",
-        appId: "app-158177ece9674aa0aa457d7938f6add0",
+        appId: "app-3b0ba0776c4349ada7fd6cedc617829b",
         integrationId: "integration.orb",
         connect: false,
         pageContext: {
           demo: "strava",
         },
         userId: "2",
-        threadId: "main"
+        threadId: randomThreadId()
     },
     launcher: {
       type: "message",

--- a/public/strava_paid_user.html
+++ b/public/strava_paid_user.html
@@ -1696,17 +1696,20 @@ Find and Invite Your Friends
   });
 </script>
 <script type="text/javascript">
+  function randomThreadId() {
+    return Math.floor(Math.random() * 1000).toString();
+}
 window.orbConfig = {
      connectionOptions: {
         gridUrl: "https://grid.meya.ai",
-        appId: "app-158177ece9674aa0aa457d7938f6add0",
+        appId: "app-3b0ba0776c4349ada7fd6cedc617829b",
         integrationId: "integration.orb",
         connect: false,
         pageContext: {
           demo: "strava",
         },
         userId: "1",
-        threadId: "main"
+        threadId: randomThreadId()
     },
     launcher: {
       type: "message",


### PR DESCRIPTION
[Codepen](https://codepen.io/ekalvi/pen/dyNrmaQ)

## Thread ID
[Slack](https://meya.slack.com/archives/C96BEA7FB/p1621613005017100?thread_ts=1621607032.010400&cid=C96BEA7FB)
Since all demo users are using the same user ID, the thread ID should be randomized so users can't see each other's conversations. This was already implemented in the Codepen, but the files in the `public` folder need this update as well.

## Update app ID
The Codepen already had the correct prod app ID, but the files in the `public` folder still had my dev app ID.

## Bug fix
The `start` flow is trying to access `flow.context.demo`, but the Orb integration settings store the context on `user` scope. There's no need to have it stored on `user` scope, so I'm removing that setting.